### PR TITLE
Update which script tag we use from BeautifulSoup to get apple music song info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,10 +48,12 @@ refresh_token = 'xxx'
 #                                           ^ This is the playlist id
 playlists = [
     {
+        'nickname': 'xxx'
         'applemusic_playlist_url': 'https://music.apple.com/us/playlist/xxx/pl.xxx',
         'spotify_playlist_id': 'xxx',
     },
     {
+        'nickname': 'xxx',
         'applemusic_playlist_url': 'https://music.apple.com/us/playlist/xxx/pl.xxx',
         'spotify_playlist_id': 'xxx',
     },


### PR DESCRIPTION
I recently tried using this to convert another playlist but it seems like Apple Music changed what/how they store song information, so the existing implementation of this converter was not able to get the song duration.

I updated `get_songs_from_apple_playlist` to use a different section of the BeautifulSoup scraped output that contains all the relevant information. Ended up needing a new method that converts the ISO 8601 representation of duration to milliseconds.

Also added the link to the spotify playlist so you can go verify that it worked. Here's what the terminal output looks like:
<img width="630" alt="apple-music-to-spotify-output" src="https://github.com/user-attachments/assets/f09b5900-4651-49b5-afce-53465b58b3f4" />
